### PR TITLE
include Cargo.lock into the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ tmp
 __pycache__
 # Ignore user specific files in Xcode Project
 xcuserdata
-Cargo.lock
 private
 release
 


### PR DESCRIPTION
This lockfile is [recommend to be checked into git](https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html#cargotoml-vs-cargolock) as it's an end-user application.

> If you’re building an end product, which are executable like command-line tool or an application, or a system library with crate-type of staticlib or cdylib, check Cargo.lock into git