### PR TITLE
chore: include tauri build dependencies

### DIFF
--- a/desktop/ui/Cargo.toml
+++ b/desktop/ui/Cargo.toml
@@ -19,3 +19,7 @@ gloo-utils = "0.1.5"
 time = { version = "0.3.15", features = [ "wasm-bindgen" ] }
 yew = { version = "0.20.0", features = ["csr"] }
 yew-agent = "0.2.0"
+
+[build-dependencies]
+tauri-build = { version = "1.2.1" }
+tauri-cli = "1.2.1"


### PR DESCRIPTION
`[build-dependencies]` should be added [for use in your build scripts](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#build-dependencies) both for standards-compliant reasons and for [generating](https://github.com/flatpak/flatpak-builder-tools/tree/master/cargo) `generated-sources.json` used for publishing to flathub.org.

Note: don't forget to update your `Cargo.lock` after merging this PR.