### PR TITLE
build: adapt to the flatpak build pipeline

### DIFF
--- a/desktop/tauri/Cargo.toml
+++ b/desktop/tauri/Cargo.toml
@@ -13,6 +13,7 @@ build = "src/build.rs"
 
 [build-dependencies]
 tauri-build = { version = "1.2.1", features = [] }
+trunk = "0.16.0"
 
 [dependencies]
 serde_json = "1.0"

--- a/desktop/tauri/Cargo.toml
+++ b/desktop/tauri/Cargo.toml
@@ -13,6 +13,7 @@ build = "src/build.rs"
 
 [build-dependencies]
 tauri-build = { version = "1.2.1", features = [] }
+tauri-cli  = "1.2.1"
 trunk = "0.16.0"
 
 [dependencies]

--- a/desktop/ui/Cargo.toml
+++ b/desktop/ui/Cargo.toml
@@ -19,7 +19,3 @@ gloo-utils = "0.1.5"
 time = { version = "0.3.15", features = [ "wasm-bindgen" ] }
 yew = { version = "0.20.0", features = ["csr"] }
 yew-agent = "0.2.0"
-
-[build-dependencies]
-tauri-build = { version = "1.2.1" }
-tauri-cli = "1.2.1"

--- a/desktop/ui/Cargo.toml
+++ b/desktop/ui/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 wasm-logger = "0.2.0"
-wasm-bindgen = "0.2"
+wasm-bindgen = { version = "0.2.84", features = ["serde-serialize"]  }
 wasm-bindgen-futures = "0.4.29"
 js-sys = "0.3.56"
 log = "0.4.16"


### PR DESCRIPTION
- trunk is used as a CLI tool in the build script, so it needs to be included in the build dependencies. 

- The `tauri` dependencies should be moved to `desktop/tauri` as that's where it's intended to be used.

- `serde-serialize` in `wasm-bindgen` is not declared. Therefore, the serde function is missing in the flatpak build pipeline.


Note: The lockfile is out of date. Specifically, it contains an old, incompatible version of `reqwest`